### PR TITLE
feat: Add config for extract operation timeout

### DIFF
--- a/app/aidbox/operations.py
+++ b/app/aidbox/operations.py
@@ -85,7 +85,7 @@ async def get_questionnaire_context_operation(request: AidboxSdcRequest):
     return web.json_response(result, dumps=json.dumps)
 
 
-@aidbox_operation(["POST"], ["Questionnaire", "$extract"])
+@aidbox_operation(["POST"], ["Questionnaire", "$extract"], timeout=settings.EXTRACT_TIMEOUT)
 @prepare_args
 async def extract_questionnaire_operation(request: AidboxSdcRequest):
     resource = request.resource
@@ -143,7 +143,9 @@ async def extract_questionnaire_operation(request: AidboxSdcRequest):
     return web.json_response(extraction_result, dumps=json.dumps)
 
 
-@aidbox_operation(["POST"], ["Questionnaire", {"name": "id"}, "$extract"])
+@aidbox_operation(
+    ["POST"], ["Questionnaire", {"name": "id"}, "$extract"], timeout=settings.EXTRACT_TIMEOUT
+)
 @prepare_args
 async def extract_questionnaire_instance_operation(request: AidboxSdcRequest):
     resource = request.resource

--- a/app/aidbox/settings.py
+++ b/app/aidbox/settings.py
@@ -19,4 +19,6 @@ settings = Settings(
     # CONSTRAINT_LEGACY_BEHAVIOR - pre-save legacy behavior of constraint when then condition was reversed
     CONSTRAINT_LEGACY_BEHAVIOR=os.getenv("CONSTRAINT_LEGACY_BEHAVIOR", "True").lower()
     == "true",
+
+    EXTRACT_TIMEOUT=int(os.getenv("EXTRACT_TIMEOUT", "60000")),
 )


### PR DESCRIPTION
Introduce env var "EXTRACT_TIMEOUT" and increase default from 30s to 60s

Required for cases with multiple mappers within one `$extract` (e.g. 30+)