### PR TITLE
Get entry from bundle safely

### DIFF
--- a/app/sdc/extract.py
+++ b/app/sdc/extract.py
@@ -21,7 +21,9 @@ async def get_external_service_bundle(session, service, template, context):
 
 async def execute_mappers_bundles(client, mappers_bundles):
     try:
-        flattened_mappers_bundles = list(flatten(bundle["entry"] for bundle in mappers_bundles))
+        flattened_mappers_bundles = list(
+            flatten(bundle.get("entry", []) for bundle in mappers_bundles)
+        )
     except:
         flattened_mappers_bundles = []
 


### PR DESCRIPTION
It is required for cases, when there are multiple mappers and some can generate empty bundles